### PR TITLE
Container build and workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,38 @@
+name: Build container and publish if on main
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build-container:
+      runs-on: ubuntu-latest
+      env:
+        REGISTRY: quay.io
+        IMAGE_NAME: rosalindfranklininstitute/volume-segmantics
+      steps:
+        - uses: actions/checkout@v6
+        - name: Log in to Quay.io
+          if: github.ref == 'refs/heads/main'
+          uses: docker/login-action@v3
+          with:
+            registry: ${{ env.REGISTRY }}
+            username: ${{ secrets.QUAY_USERNAME }}
+            password: ${{ secrets.QUAY_PASSWORD }}
+        - name: Extract image metadata
+          if: github.ref == 'refs/heads/main'
+          id: meta
+          uses: docker/metadata-action@v5
+          with:
+            images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+            tags: |
+              type=raw,value=latest
+              type=sha,format=short
+        - name: Set up Docker Buildx
+          uses: docker/setup-buildx-action@v3
+        - name: Build container (and push if main)
+          uses: docker/build-push-action@v6
+          with:
+            context: .
+            outputs: ${{ github.ref == 'refs/heads/main' && 'type=docker,type=registry' || 'type=docker' }}
+            tags: ${{ steps.meta.outputs.tags || 'volume-segmantics:ci' }}
+            labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,40 @@
+FROM ubuntu:22.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y \
+    wget \
+    git \
+    python3 \
+    python3-pip \
+    libglib2.0-0 \
+    && rm -rf /var/lib/apt/lists/*
+
+# Add NVIDIA CUDA repository and install runtime libraries only
+RUN wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-keyring_1.1-1_all.deb \
+    && dpkg -i cuda-keyring_1.1-1_all.deb \
+    && rm cuda-keyring_1.1-1_all.deb \
+    && apt-get update && apt-get install -y \
+    cuda-libraries-12-6 \
+    libcudnn9-cuda-12 \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN ln -s /usr/bin/python3 /usr/local/bin/python
+
+RUN git clone https://github.com/rosalindfranklininstitute/volume-segmantics.git /opt/volume-segmantics
+WORKDIR /opt/volume-segmantics
+
+RUN pip install --no-cache-dir poetry
+
+RUN pip install --no-cache-dir \
+    torch==2.7.1 \
+    --index-url https://download.pytorch.org/whl/cu126
+
+RUN poetry config virtualenvs.create false \
+    && poetry install --no-root \
+    && pip uninstall -y opencv-python \
+    && pip install --no-cache-dir "opencv-python-headless==4.11.0.86"
+
+WORKDIR /root
+
+CMD ["/bin/bash"]

--- a/README.md
+++ b/README.md
@@ -16,7 +16,32 @@ A machine capable of running CUDA enabled PyTorch version 2.0 or greater is requ
 
 ## Installation
 
-The easiest way to install the package is to first create a new conda environment or virtualenv with python (ideally >= version 3.10) and also pip, then activate the environment and `pip install volume-segmantics`. If a CUDA-enabled build of PyTorch is not being installed by pip, you can try `pip install volume-segmantics --extra-index-url https://download.pytorch.org/whl` this particularity seems to be an issue on Windows. 
+### Conda/Virtualenv (PyPI)
+
+The latest published release may be installed from the Python Package Index in a new conda environment or virtualenv with python (ideally >= version 3.10) and pip: activate the environment and `pip install volume-segmantics`. 
+
+If you find a CUDA-enabled build of PyTorch is not being installed by pip (this particularity seems to be an issue on Windows), you can try `pip install volume-segmantics --extra-index-url https://download.pytorch.org/whl`.
+
+### Docker/Apptainer Container (quay.io)
+A container image with the latest published release is available on the
+Rosalind Franklin's quay.io instance. You can pull and run this using
+Apptainer:
+```
+apptainer run --nv docker://quay.io/rosalindfranklininstitute/volume-segmantics
+```
+Or docker:
+```
+docker run \
+    --gpus all \
+    --ipc=host \
+    -v /path/to/data:/data
+    quay.io/rosalindfranklininstitute/volume-segmantics
+```
+Note `--ipc=host` grants the container access to host shared
+memory, since the default allocation in Docker (64M) may
+be insufficient. More details can be found
+on the [Volume EM Container documentation](https://rosalindfranklininstitute.github.io/volume-em-container-documentation/software/volume-segmantics/).
+
 
 ## Configuration and command line use
 


### PR DESCRIPTION
Integrate Dockerfile and Workflow from https://github.com/rosalindfranklininstitute/volume-segmantics-container

The workflow is currently set to run on manually trigger only

In order for the workflow to publish RFI's quay.io container registry, credentials are required as GitHub secrets (I will need write access to add these)